### PR TITLE
Use native ARM64 runners in GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/openwrt-build-master.yml
+++ b/.github/workflows/openwrt-build-master.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     
     steps:
     - name: Checkout Repository
@@ -56,8 +56,6 @@ jobs:
           bison \
           g++ \
           gawk \
-          gcc-multilib \
-          g++-multilib \
           gettext \
           git \
           libncurses-dev \

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
     - name: Checkout Repository
@@ -56,8 +56,6 @@ jobs:
           bison \
           g++ \
           gawk \
-          gcc-multilib \
-          g++-multilib \
           gettext \
           git \
           libncurses-dev \


### PR DESCRIPTION
These became available just over the past weeks. The build time is shorter (about 30% gain) as it saves on compute without having to emulate a different arch.